### PR TITLE
Update _navbar.scss

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -163,7 +163,8 @@ nav {
       font-size: 1.2rem;
       border: none;
       padding-left: 2rem;
-
+      padding-right: 2rem;
+      box-sizing:border-box;
       &:focus, &[type=text]:valid, &[type=password]:valid,
       &[type=email]:valid, &[type=url]:valid, &[type=date]:valid {
         border: none;


### PR DESCRIPTION
## Input form
The text overlaps the cross icon

## Fix
Add  padding and box-sizing to prevent
```
padding-right:2rem;
box-sizing:border-box;
```
